### PR TITLE
ci: drop unused arm64 runner from bundle matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest-x86-4-cores
-          - ubuntu-24.04-arm64-4-core
           - macos-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -173,4 +173,26 @@ flag and argument to `hhfab init` along with other flags. From there continue
 * `hhfab vlab gen`
 * `hhfab vlab up --mode iso`
 
+## Documentation
+
+### Getting Started
+
+- **[Usage Guide](docs/usage/USAGE_GUIDE.md)** - Comprehensive usage instructions with examples
+- **[Debug Guide](docs/debug/DEBUG_GUIDE.md)** - Debugging tools and techniques
+- **[Troubleshooting](docs/debug/TROUBLESHOOTING.md)** - Solutions to common problems
+
+### Helper Tools
+
+Debug helper scripts are available in `hack/debug/`:
+
+- `collect-debug-info.sh` - Collect system and environment information
+- `verify-system.sh` - Verify system meets requirements
+- `check-vlab-health.sh` - Check VLAB environment health
+
+### Additional Documentation
+
+- **[API Reference](docs/api.md)** - Fabricator API documentation
+- **[Trivy Security Scans](hack/README_Trivy_Scans.md)** - Security scanning guide
+- **[Test Diagrams](hack/README_Test_Diagrams.md)** - Testing documentation
+
 

--- a/docs/debug/DEBUG_GUIDE.md
+++ b/docs/debug/DEBUG_GUIDE.md
@@ -1,0 +1,708 @@
+# Fabricator Debug Guide
+
+**Version:** 1.0
+**Date:** 2025-11-08
+**Issue:** #8
+
+## Overview
+
+This guide provides comprehensive debugging instructions for Hedgehog Fabricator development. It covers common debugging scenarios, tools, techniques, and troubleshooting procedures.
+
+## Table of Contents
+
+1. [Debug Modes and Logging](#debug-modes-and-logging)
+2. [Build Debug](#build-debug)
+3. [VLAB Debug](#vlab-debug)
+4. [Installation Debug](#installation-debug)
+5. [Network Debug](#network-debug)
+6. [Kubernetes Debug](#kubernetes-debug)
+7. [Cache and Artifact Debug](#cache-and-artifact-debug)
+8. [Debug Tools](#debug-tools)
+
+---
+
+## Debug Modes and Logging
+
+### Verbose Mode
+
+Enable verbose logging for detailed output:
+
+```bash
+# For hhfab commands
+hhfab --verbose <command>
+hhfab -v <command>
+
+# Set via environment variable
+export HHFAB_VERBOSE=true
+hhfab <command>
+```
+
+### Brief Mode
+
+Minimize output for clean logs:
+
+```bash
+hhfab --brief <command>
+```
+
+### Log Files
+
+Default log locations:
+
+| Component | Log Location | Description |
+|-----------|-------------|-------------|
+| hhfab | stdout/stderr | Main command output |
+| hhfab-install | `/var/log/hhfab-install.log` | Installation logs on control nodes |
+| systemd services | `journalctl -u <service>` | System service logs |
+| K3s | `/var/log/k3s.log` | Kubernetes logs |
+| fabricator controller | `kubectl logs -n fabricator-system` | Controller logs |
+
+### View Installation Logs
+
+On a control/gateway node after installation:
+
+```bash
+# View installation service logs
+journalctl -u hhfab-install.service
+
+# Follow live installation
+journalctl -fu hhfab-install.service
+
+# View specific time range
+journalctl -u hhfab-install.service --since "10 minutes ago"
+
+# Export logs to file
+journalctl -u hhfab-install.service > install.log
+```
+
+---
+
+## Build Debug
+
+### Build Cache Debug
+
+Check build cache status:
+
+```bash
+# View cache directory
+ls -lah ~/.hhfab-cache/v1/
+
+# Check cache size
+du -sh ~/.hhfab-cache/
+
+# Clear cache to force rebuild
+rm -rf ~/.hhfab-cache/v1/*
+```
+
+### Build Hash Debug
+
+Understand why builds are being skipped or rebuilt:
+
+```bash
+# View build hash files
+find /path/to/workdir/result -name "*.inhash"
+
+# Read hash file
+cat /path/to/workdir/result/control--ctrl-1--install.inhash | base64 -d | xxd
+```
+
+The hash includes:
+- Fabricator version
+- `fab.yaml` content
+- `include.yaml` content (wiring diagrams)
+- Build mode
+
+### Artifact Download Debug
+
+Enable verbose logging to see download progress:
+
+```bash
+hhfab --verbose build --mode iso
+```
+
+Check for download errors:
+
+```bash
+# Test OCI registry connectivity
+docker login ghcr.io
+
+# Manually test artifact download
+oras pull ghcr.io/githedgehog/fabricator/k3s-airgap:v1.34.1-k3s1
+```
+
+### Build Failure Debug
+
+When build fails:
+
+1. **Check verbose output:**
+   ```bash
+   hhfab --verbose build --mode iso 2>&1 | tee build-debug.log
+   ```
+
+2. **Verify prerequisites:**
+   ```bash
+   # Check Docker is running
+   docker ps
+
+   # Check disk space
+   df -h
+
+   # Check available memory
+   free -h
+   ```
+
+3. **Check intermediate files:**
+   ```bash
+   ls -lah /path/to/workdir/result/
+   ```
+
+4. **Force clean rebuild:**
+   ```bash
+   # Remove result directory
+   rm -rf /path/to/workdir/result
+
+   # Clear cache
+   rm -rf ~/.hhfab-cache/v1/*
+
+   # Rebuild
+   hhfab --verbose build --mode iso
+   ```
+
+---
+
+## VLAB Debug
+
+### VLAB Status Check
+
+```bash
+# Check VLAB status
+hhfab vlab status
+
+# Check VM processes
+ps aux | grep qemu
+
+# Check libvirt VMs (if using libvirt mode)
+virsh list --all
+```
+
+### VLAB Network Debug
+
+```bash
+# Check network interfaces
+ip link show
+
+# Check bridges
+brctl show
+
+# Check routes
+ip route
+
+# Check iptables rules
+sudo iptables -L -n -v
+```
+
+### VLAB Console Access
+
+Access VM consoles for debugging:
+
+```bash
+# Connect to control node console
+virsh console control-1
+
+# Connect via serial (if configured)
+screen /dev/pts/X
+
+# Disconnect: Ctrl+] then Ctrl+5
+```
+
+### VLAB Log Files
+
+```bash
+# Check VLAB runner logs
+hhfab --verbose vlab up --mode iso
+
+# Check individual VM logs
+tail -f /var/log/libvirt/qemu/control-1.log
+```
+
+---
+
+## Installation Debug
+
+### Pre-Installation Checks
+
+Before troubleshooting failed installation:
+
+```bash
+# Verify network configuration
+ip addr show
+ip route show
+
+# Verify DNS resolution
+nslookup google.com
+
+# Verify time sync
+timedatectl status
+
+# Check disk space
+df -h
+```
+
+### Installation Service Debug
+
+```bash
+# Check service status
+systemctl status hhfab-install.service
+
+# View recent logs
+journalctl -u hhfab-install.service -n 100
+
+# Follow logs live
+journalctl -fu hhfab-install.service
+
+# Check for failures
+journalctl -u hhfab-install.service -p err
+```
+
+### Installation Marker Files
+
+```bash
+# Check if installation completed
+ls -la /opt/hedgehog/.install
+
+# If exists and contains "complete", installation succeeded
+cat /opt/hedgehog/.install
+```
+
+### Manual Installation Debug
+
+Run installation steps manually:
+
+```bash
+# SSH to control node
+ssh core@<control-ip>
+
+# Navigate to installation directory
+cd /opt/hedgehog/control--ctrl-1--install
+
+# Run installer with verbose output
+sudo ./hhfab-recipe install -v
+
+# Check specific step output
+sudo ./hhfab-recipe install -v 2>&1 | grep -A 10 "Step: Install K3s"
+```
+
+### K3s Installation Debug
+
+```bash
+# Check K3s service
+systemctl status k3s
+
+# Check K3s logs
+journalctl -u k3s -n 100
+
+# Check node status
+kubectl get nodes
+
+# Check pods
+kubectl get pods -A
+```
+
+---
+
+## Network Debug
+
+### Interface Configuration Debug
+
+```bash
+# Show all interfaces
+ip addr show
+
+# Show specific interface
+ip addr show eth0
+
+# Check interface statistics
+ip -s link show eth0
+
+# Test connectivity
+ping -c 3 <ip-address>
+```
+
+### DNS Debug
+
+```bash
+# Check DNS configuration
+cat /etc/resolv.conf
+
+# Test DNS resolution
+nslookup google.com
+dig google.com
+
+# Test internal DNS
+nslookup fabricator.fabricator-system.svc.cluster.local
+```
+
+### Firewall Debug
+
+```bash
+# Check iptables rules
+sudo iptables -L -n -v
+
+# Check for blocked ports
+sudo iptables -L INPUT -n -v | grep DROP
+
+# Temporarily disable firewall (for testing only)
+sudo systemctl stop firewalld
+```
+
+---
+
+## Kubernetes Debug
+
+### Cluster Debug
+
+```bash
+# Check cluster info
+kubectl cluster-info
+
+# Check component status
+kubectl get componentstatuses
+
+# Check nodes
+kubectl get nodes -o wide
+
+# Check system pods
+kubectl get pods -n kube-system
+```
+
+### Pod Debug
+
+```bash
+# Check pod status
+kubectl get pods -A
+
+# Describe pod (shows events)
+kubectl describe pod <pod-name> -n <namespace>
+
+# View pod logs
+kubectl logs <pod-name> -n <namespace>
+
+# View previous pod logs (if crashed)
+kubectl logs <pod-name> -n <namespace> --previous
+
+# Follow logs live
+kubectl logs -f <pod-name> -n <namespace>
+
+# Execute commands in pod
+kubectl exec -it <pod-name> -n <namespace> -- /bin/bash
+```
+
+### Service Debug
+
+```bash
+# Check services
+kubectl get svc -A
+
+# Check endpoints
+kubectl get endpoints -A
+
+# Test service connectivity from pod
+kubectl run -it --rm debug --image=alpine --restart=Never -- sh
+# Inside pod:
+wget -O- http://service-name.namespace.svc.cluster.local
+```
+
+### Events Debug
+
+```bash
+# View all events
+kubectl get events -A --sort-by='.lastTimestamp'
+
+# View events for specific namespace
+kubectl get events -n fabricator-system
+
+# Watch events live
+kubectl get events -A --watch
+```
+
+---
+
+## Cache and Artifact Debug
+
+### Cache Directory Structure
+
+```bash
+# View cache structure
+tree -L 2 ~/.hhfab-cache/v1/
+
+# Check cache sizes
+du -sh ~/.hhfab-cache/v1/*
+
+# Find large artifacts
+du -ah ~/.hhfab-cache/v1/ | sort -rh | head -20
+```
+
+### Artifact Verification
+
+```bash
+# Verify artifact checksums
+cd ~/.hhfab-cache/v1/fabricator_k3s-airgap@v1.34.1-k3s1.oras/
+sha256sum k3s k3s-install.sh k3s-airgap-images-amd64.tar.gz
+```
+
+### Registry Connection Debug
+
+```bash
+# Test registry connectivity
+oras pull --insecure ghcr.io/githedgehog/fabricator/k3s-airgap:v1.34.1-k3s1
+
+# Test with authentication
+docker login ghcr.io
+oras pull ghcr.io/githedgehog/fabricator/k3s-airgap:v1.34.1-k3s1
+```
+
+### Cache Cleanup
+
+```bash
+# Remove specific artifact from cache
+rm -rf ~/.hhfab-cache/v1/fabricator_k3s-airgap@v1.34.1-k3s1.oras/
+
+# Clear all cache
+rm -rf ~/.hhfab-cache/v1/*
+
+# Rebuild cache
+hhfab build --mode iso
+```
+
+---
+
+## Debug Tools
+
+### Built-in Debug Commands
+
+```bash
+# Run any hhfab command with minimal Go flags (for development)
+just run hhfab <args>
+
+# Example: Test config loading
+just run hhfab init --dev
+
+# Run with specific log level
+hhfab --verbose <command>
+```
+
+### Helper Scripts
+
+Located in `hack/debug/`:
+
+```bash
+# Collect debug information
+./hack/debug/collect-debug-info.sh
+
+# Verify system requirements
+./hack/debug/verify-system.sh
+
+# Check VLAB health
+./hack/debug/check-vlab-health.sh
+```
+
+See [Debug Scripts](#debug-scripts) section for script details.
+
+### K9s (Kubernetes CLI)
+
+Interactive Kubernetes debugging:
+
+```bash
+# Launch K9s
+k9s
+
+# Navigate:
+# - 0-9: Switch contexts
+# - : (colon): Command mode
+# - /: Search
+# - l: Logs
+# - d: Describe
+# - e: Edit
+# - Ctrl+d: Delete
+```
+
+---
+
+## Common Issues and Solutions
+
+### Issue: Build hangs during artifact download
+
+**Symptoms:**
+- Build freezes at download step
+- No progress output
+
+**Diagnosis:**
+```bash
+# Check network connectivity
+ping ghcr.io
+
+# Check Docker authentication
+cat ~/.docker/config.json
+```
+
+**Solution:**
+```bash
+# Re-authenticate with registry
+docker login ghcr.io
+
+# Retry build with verbose output
+hhfab --verbose build --mode iso
+```
+
+---
+
+### Issue: Installation fails with "network not ready"
+
+**Symptoms:**
+- Installation logs show network timeout errors
+- `hhfab-install.service` fails
+
+**Diagnosis:**
+```bash
+journalctl -u hhfab-install.service | grep -i "network"
+ip addr show
+```
+
+**Solution:**
+```bash
+# Verify Ignition applied network config
+cat /run/ignition.json | jq '.storage.files[] | select(.path=="/etc/systemd/network/*")'
+
+# Restart networking
+systemctl restart systemd-networkd
+
+# Retry installation
+systemctl restart hhfab-install.service
+```
+
+---
+
+### Issue: K3s fails to start
+
+**Symptoms:**
+- K3s service fails
+- Pods don't start
+
+**Diagnosis:**
+```bash
+systemctl status k3s
+journalctl -u k3s | tail -50
+```
+
+**Solution:**
+```bash
+# Check K3s config
+cat /etc/rancher/k3s/config.yaml
+
+# Check K3s binary
+which k3s
+k3s --version
+
+# Restart K3s
+systemctl restart k3s
+
+# Check node status
+kubectl get nodes
+```
+
+---
+
+### Issue: Cache corruption
+
+**Symptoms:**
+- Build fails with "unexpected EOF" or checksum errors
+- Artifacts appear incomplete
+
+**Diagnosis:**
+```bash
+# Check cache integrity
+ls -lh ~/.hhfab-cache/v1/fabricator_*
+
+# Verify file sizes match expected
+```
+
+**Solution:**
+```bash
+# Clear cache
+rm -rf ~/.hhfab-cache/v1/*
+
+# Rebuild
+hhfab build --mode iso
+```
+
+---
+
+## Advanced Debugging
+
+### Enable Go Debug Logging
+
+For developers debugging Go code:
+
+```bash
+# Run with Go debugging
+GODEBUG=gctrace=1 hhfab build --mode iso
+
+# Run with pprof profiling
+go run -race ./cmd/hhfab build --mode iso
+```
+
+### Attach Debugger (Delve)
+
+```bash
+# Install delve
+go install github.com/go-delve/delve/cmd/dlv@latest
+
+# Debug hhfab
+dlv debug ./cmd/hhfab -- build --mode iso
+
+# Set breakpoint
+(dlv) break pkg/hhfab/cmdbuild.go:50
+
+# Continue execution
+(dlv) continue
+```
+
+### Network Packet Capture
+
+```bash
+# Capture network traffic
+sudo tcpdump -i eth0 -w debug.pcap
+
+# Analyze with Wireshark
+wireshark debug.pcap
+```
+
+---
+
+## Getting Help
+
+If you're stuck:
+
+1. **Check logs** with verbose output
+2. **Review** this debug guide and troubleshooting guide
+3. **Search** existing GitHub issues
+4. **File an issue** with:
+   - Command that failed
+   - Full verbose output
+   - Environment details (OS, kernel, Docker version)
+   - Output of `./hack/debug/collect-debug-info.sh`
+
+---
+
+## Related Documentation
+
+- [Usage Guide](../usage/USAGE_GUIDE.md) - Common usage patterns
+- [Troubleshooting Guide](../debug/TROUBLESHOOTING.md) - Specific problem solutions
+- [README](../../README.md) - Project overview and setup
+- [Build Guide](../../README.md#local-build-instructions) - Building Fabricator
+
+---
+
+**Last Updated:** 2025-11-08
+**Maintained By:** Hedgehog Fabricator Team
+**Issue:** #8

--- a/docs/debug/TROUBLESHOOTING.md
+++ b/docs/debug/TROUBLESHOOTING.md
@@ -1,0 +1,880 @@
+# Fabricator Troubleshooting Guide
+
+**Version:** 1.0
+**Date:** 2025-11-08
+**Issue:** #8
+
+## Overview
+
+This guide provides specific solutions to common problems encountered when using Hedgehog Fabricator. Each issue includes symptoms, diagnosis steps, and tested solutions.
+
+## Table of Contents
+
+1. [Build Issues](#build-issues)
+2. [Installation Issues](#installation-issues)
+3. [VLAB Issues](#vlab-issues)
+4. [Network Issues](#network-issues)
+5. [Kubernetes Issues](#kubernetes-issues)
+6. [Performance Issues](#performance-issues)
+
+---
+
+## Build Issues
+
+### Issue: Build hangs during artifact download
+
+**Symptoms:**
+- Build process stops responding
+- No output for extended period
+- Last message shows artifact download starting
+
+**Diagnosis:**
+```bash
+# Check network connectivity
+ping -c 3 ghcr.io
+
+# Check firewall/proxy settings
+env | grep -i proxy
+
+# Test registry access
+curl -I https://ghcr.io/v2/
+```
+
+**Solutions:**
+
+1. **Check Docker authentication:**
+   ```bash
+   # Re-login to registry
+   docker login ghcr.io
+   # Enter your GitHub username and token
+   ```
+
+2. **Clear cache and retry:**
+   ```bash
+   rm -rf ~/.hhfab-cache/v1/*
+   hhfab --verbose build --mode iso
+   ```
+
+3. **Check network/proxy:**
+   ```bash
+   # If behind proxy, configure Docker
+   sudo mkdir -p /etc/systemd/system/docker.service.d
+   sudo cat > /etc/systemd/system/docker.service.d/http-proxy.conf <<EOF
+   [Service]
+   Environment="HTTP_PROXY=http://proxy.example.com:8080"
+   Environment="HTTPS_PROXY=http://proxy.example.com:8080"
+   Environment="NO_PROXY=localhost,127.0.0.1"
+   EOF
+   sudo systemctl daemon-reload
+   sudo systemctl restart docker
+   ```
+
+---
+
+### Issue: Build fails with "disk space" error
+
+**Symptoms:**
+- Build terminates with "no space left on device"
+- Large ISO/IMG files fail to create
+
+**Diagnosis:**
+```bash
+# Check available disk space
+df -h
+
+# Check cache size
+du -sh ~/.hhfab-cache/
+
+# Check workdir size
+du -sh workdir/
+```
+
+**Solutions:**
+
+1. **Clean up old artifacts:**
+   ```bash
+   # Remove old result files
+   rm -rf workdir/result/*
+
+   # Clear cache
+   rm -rf ~/.hhfab-cache/v1/*
+
+   # Clean Docker images
+   docker system prune -a
+   ```
+
+2. **Move cache to larger disk:**
+   ```bash
+   # Move cache
+   mkdir -p /mnt/large-disk/hhfab-cache
+   mv ~/.hhfab-cache/* /mnt/large-disk/hhfab-cache/
+   ln -s /mnt/large-disk/hhfab-cache ~/.hhfab-cache
+
+   # Or set environment variable
+   export HHFAB_CACHE_DIR=/mnt/large-disk/hhfab-cache
+   ```
+
+---
+
+### Issue: Build fails with "permission denied"
+
+**Symptoms:**
+- Build fails accessing cache directory
+- Errors mention file permissions
+
+**Diagnosis:**
+```bash
+# Check cache permissions
+ls -la ~/.hhfab-cache/
+
+# Check workdir permissions
+ls -la workdir/
+```
+
+**Solutions:**
+
+1. **Fix cache permissions:**
+   ```bash
+   # Fix ownership
+   sudo chown -R $USER:$USER ~/.hhfab-cache/
+
+   # Fix permissions
+   chmod -R 755 ~/.hhfab-cache/
+   ```
+
+2. **Recreate cache directory:**
+   ```bash
+   rm -rf ~/.hhfab-cache/
+   mkdir -p ~/.hhfab-cache/v1/
+   hhfab build --mode iso
+   ```
+
+---
+
+### Issue: Build creates corrupted ISO
+
+**Symptoms:**
+- ISO file created but won't boot
+- Checksum verification fails
+- ISO appears truncated
+
+**Diagnosis:**
+```bash
+# Check ISO file integrity
+file workdir/result/control--*.iso
+
+# Check size
+ls -lh workdir/result/control--*.iso
+# Should be ~9-10 GB for standard, ~12-15 GB for airgap
+
+# Try mounting ISO
+sudo mount -o loop workdir/result/control--ctrl-1--install-usb.iso /mnt
+ls -la /mnt
+sudo umount /mnt
+```
+
+**Solutions:**
+
+1. **Rebuild with clean cache:**
+   ```bash
+   rm -rf ~/.hhfab-cache/v1/*
+   rm -rf workdir/result/*
+   hhfab --verbose build --mode iso 2>&1 | tee build.log
+   ```
+
+2. **Verify download integrity:**
+   ```bash
+   # Re-download specific artifact
+   rm -rf ~/.hhfab-cache/v1/fabricator_k3s-airgap@*
+   hhfab build --mode iso
+   ```
+
+---
+
+## Installation Issues
+
+### Issue: Installation fails with "network not ready"
+
+**Symptoms:**
+- `hhfab-install.service` fails
+- Logs show network timeouts
+- Installation retries and fails
+
+**Diagnosis:**
+```bash
+# SSH to node
+ssh core@<node-ip>
+
+# Check network configuration
+ip addr show
+ip route show
+
+# Check logs
+journalctl -u hhfab-install.service | grep -i network
+```
+
+**Solutions:**
+
+1. **Verify Ignition applied network config:**
+   ```bash
+   # Check systemd network files
+   ls -la /etc/systemd/network/
+
+   # Check specific interface config
+   cat /etc/systemd/network/10-eth0.network
+
+   # Restart networking
+   sudo systemctl restart systemd-networkd
+   sudo systemctl restart systemd-resolved
+   ```
+
+2. **Manually configure network:**
+   ```bash
+   # Create network config
+   sudo cat > /etc/systemd/network/10-eth0.network <<EOF
+   [Match]
+   Name=eth0
+
+   [Network]
+   Address=10.10.10.10/24
+   Gateway=10.10.10.1
+   DNS=8.8.8.8
+   EOF
+
+   # Apply
+   sudo systemctl restart systemd-networkd
+
+   # Retry installation
+   sudo systemctl restart hhfab-install.service
+   ```
+
+---
+
+### Issue: K3s fails to start during installation
+
+**Symptoms:**
+- Installation hangs at K3s step
+- `k3s.service` fails to start
+- Timeout waiting for K3s
+
+**Diagnosis:**
+```bash
+# Check K3s service status
+sudo systemctl status k3s
+
+# Check logs
+sudo journalctl -u k3s | tail -100
+
+# Check K3s config
+cat /etc/rancher/k3s/config.yaml
+```
+
+**Solutions:**
+
+1. **Check K3s configuration:**
+   ```bash
+   # Verify config syntax
+   cat /etc/rancher/k3s/config.yaml
+
+   # Common issues:
+   # - Invalid IP addresses
+   # - Incorrect TLS SANs
+   # - Missing node-ip
+
+   # Fix and restart
+   sudo systemctl restart k3s
+   ```
+
+2. **Clean and reinstall K3s:**
+   ```bash
+   # Stop K3s
+   sudo systemctl stop k3s
+
+   # Remove K3s data
+   sudo rm -rf /var/lib/rancher/k3s
+
+   # Reinstall
+   cd /opt/hedgehog/control--ctrl-1--install
+   sudo INSTALL_K3S_SKIP_DOWNLOAD=true ./k3s-install.sh
+
+   # Verify
+   sudo systemctl status k3s
+   kubectl get nodes
+   ```
+
+---
+
+### Issue: Zot registry fails to start
+
+**Symptoms:**
+- Zot deployment not ready
+- Installation times out waiting for Zot
+- Pods in CrashLoopBackOff
+
+**Diagnosis:**
+```bash
+# Check Zot pods
+kubectl get pods -n zot
+
+# Check pod logs
+kubectl logs -n zot deployment/zot
+
+# Check pod events
+kubectl describe pod -n zot <pod-name>
+```
+
+**Solutions:**
+
+1. **Check persistent volume:**
+   ```bash
+   # Check PVC status
+   kubectl get pvc -n zot
+
+   # Check storage class
+   kubectl get storageclass
+
+   # If PVC pending, check for storage issues
+   kubectl describe pvc -n zot zot-data
+   ```
+
+2. **Restart Zot deployment:**
+   ```bash
+   # Delete pod to recreate
+   kubectl delete pod -n zot -l app=zot
+
+   # Wait for new pod
+   kubectl wait --for=condition=ready pod -n zot -l app=zot --timeout=300s
+   ```
+
+---
+
+### Issue: Certificate manager webhook not ready
+
+**Symptoms:**
+- Installation hangs at cert-manager step
+- Webhook pod not responding
+- Timeout errors
+
+**Diagnosis:**
+```bash
+# Check cert-manager pods
+kubectl get pods -n cert-manager
+
+# Check webhook specifically
+kubectl get pods -n cert-manager -l app=webhook
+
+# Check logs
+kubectl logs -n cert-manager deployment/cert-manager-webhook
+```
+
+**Solutions:**
+
+1. **Wait longer (cert-manager can be slow):**
+   ```bash
+   # Manually wait for webhook
+   kubectl wait --for=condition=available deployment/cert-manager-webhook \
+     -n cert-manager --timeout=600s
+   ```
+
+2. **Restart cert-manager:**
+   ```bash
+   # Delete webhook pod
+   kubectl delete pod -n cert-manager -l app=webhook
+
+   # Wait for recreation
+   kubectl wait --for=condition=available deployment/cert-manager-webhook \
+     -n cert-manager --timeout=300s
+   ```
+
+---
+
+## VLAB Issues
+
+### Issue: VLAB fails to start VMs
+
+**Symptoms:**
+- `hhfab vlab up` fails
+- No QEMU processes running
+- Error messages about libvirt
+
+**Diagnosis:**
+```bash
+# Check libvirt is running
+sudo systemctl status libvirtd
+
+# Check for existing VMs
+virsh list --all
+
+# Check network bridges
+ip link show
+brctl show
+```
+
+**Solutions:**
+
+1. **Clean up stale resources:**
+   ```bash
+   # Kill stale processes
+   hhfab vlab down --force
+
+   # Kill any remaining QEMU
+   sudo pkill -9 qemu
+
+   # Remove stale VMs
+   for vm in $(virsh list --all --name); do
+     virsh destroy $vm
+     virsh undefine $vm
+   done
+
+   # Retry
+   hhfab vlab up --mode iso --recreate
+   ```
+
+2. **Restart libvirt:**
+   ```bash
+   sudo systemctl restart libvirtd
+   hhfab vlab up --mode iso
+   ```
+
+---
+
+### Issue: VLAB VMs won't boot
+
+**Symptoms:**
+- VMs created but don't boot
+- Console shows no output
+- Boot hangs
+
+**Diagnosis:**
+```bash
+# Check VM status
+virsh list --all
+
+# Check VM console
+virsh console control-1
+# (Ctrl+] then Ctrl+5 to disconnect)
+
+# Check VM logs
+tail -f /var/log/libvirt/qemu/control-1.log
+```
+
+**Solutions:**
+
+1. **Verify boot configuration:**
+   ```bash
+   # Check VM XML
+   virsh dumpxml control-1 | grep -A 10 "<os>"
+
+   # Ensure UEFI boot configured
+   # Should have <loader> element pointing to OVMF
+   ```
+
+2. **Recreate VMs:**
+   ```bash
+   # Destroy and undefine
+   virsh destroy control-1
+   virsh undefine control-1
+
+   # Rebuild VLAB
+   hhfab vlab up --mode iso --recreate
+   ```
+
+---
+
+### Issue: VLAB network not working
+
+**Symptoms:**
+- VMs can't communicate
+- No network connectivity
+- SSH fails
+
+**Diagnosis:**
+```bash
+# Check bridges
+brctl show
+
+# Check IP forwarding
+cat /proc/sys/net/ipv4/ip_forward
+# Should be 1
+
+# Check iptables
+sudo iptables -L -n -v
+```
+
+**Solutions:**
+
+1. **Enable IP forwarding:**
+   ```bash
+   # Enable temporarily
+   sudo sysctl -w net.ipv4.ip_forward=1
+
+   # Enable permanently
+   echo "net.ipv4.ip_forward=1" | sudo tee -a /etc/sysctl.conf
+   sudo sysctl -p
+   ```
+
+2. **Recreate network:**
+   ```bash
+   # Stop VLAB
+   hhfab vlab down
+
+   # Remove network configuration
+   # (VLAB will recreate on next up)
+
+   # Restart VLAB
+   hhfab vlab up --mode iso
+   ```
+
+---
+
+## Network Issues
+
+### Issue: Nodes can't resolve DNS
+
+**Symptoms:**
+- `nslookup` fails
+- Package downloads fail
+- Kubectl commands timeout
+
+**Diagnosis:**
+```bash
+# Check resolv.conf
+cat /etc/resolv.conf
+
+# Test DNS
+nslookup google.com
+dig google.com
+
+# Test specific nameserver
+nslookup google.com 8.8.8.8
+```
+
+**Solutions:**
+
+1. **Configure DNS manually:**
+   ```bash
+   # Edit resolv.conf
+   sudo cat > /etc/resolv.conf <<EOF
+   nameserver 8.8.8.8
+   nameserver 1.1.1.1
+   EOF
+
+   # Make immutable to prevent overwrites
+   sudo chattr +i /etc/resolv.conf
+
+   # Test
+   nslookup google.com
+   ```
+
+2. **Fix systemd-resolved:**
+   ```bash
+   # Check resolved status
+   sudo systemctl status systemd-resolved
+
+   # Restart
+   sudo systemctl restart systemd-resolved
+
+   # Verify
+   resolvectl status
+   ```
+
+---
+
+### Issue: Control VIP not accessible
+
+**Symptoms:**
+- Can't access control services via VIP
+- VIP not responding to ping
+- Services only accessible via node IP
+
+**Diagnosis:**
+```bash
+# Check VIP configuration
+ip addr show | grep <vip>
+
+# Check dummy interface
+ip addr show dummy0
+
+# Check routing
+ip route show
+```
+
+**Solutions:**
+
+1. **Verify VIP configured:**
+   ```bash
+   # Check if VIP assigned to dummy interface
+   ip addr show dummy0
+
+   # If missing, add manually
+   sudo ip addr add <vip>/24 dev dummy0
+   sudo ip link set dummy0 up
+   ```
+
+2. **Restart networking:**
+   ```bash
+   sudo systemctl restart systemd-networkd
+   ip addr show dummy0
+   ```
+
+---
+
+## Kubernetes Issues
+
+### Issue: Pods stuck in Pending state
+
+**Symptoms:**
+- Pods don't start
+- Status shows "Pending"
+- No progress
+
+**Diagnosis:**
+```bash
+# Describe pod to see events
+kubectl describe pod <pod-name> -n <namespace>
+
+# Check node resources
+kubectl top nodes
+
+# Check events
+kubectl get events -n <namespace> --sort-by='.lastTimestamp'
+```
+
+**Solutions:**
+
+1. **Resource constraints:**
+   ```bash
+   # If insufficient resources, clean up
+   kubectl delete pod <unused-pod> -n <namespace>
+
+   # Or scale down deployments
+   kubectl scale deployment <name> --replicas=0 -n <namespace>
+   ```
+
+2. **PersistentVolumeClaim issues:**
+   ```bash
+   # Check PVC status
+   kubectl get pvc -n <namespace>
+
+   # If pending, check storage class
+   kubectl get storageclass
+
+   # Describe PVC for details
+   kubectl describe pvc <pvc-name> -n <namespace>
+   ```
+
+---
+
+### Issue: Service endpoints not ready
+
+**Symptoms:**
+- Service exists but has no endpoints
+- Connections refused
+- Pods running but service not working
+
+**Diagnosis:**
+```bash
+# Check service
+kubectl get svc -n <namespace>
+
+# Check endpoints
+kubectl get endpoints -n <namespace>
+
+# Check if endpoints match pods
+kubectl get pods -n <namespace> -o wide
+```
+
+**Solutions:**
+
+1. **Verify pod labels match service selector:**
+   ```bash
+   # Check service selector
+   kubectl get svc <service-name> -n <namespace> -o yaml | grep -A 5 selector
+
+   # Check pod labels
+   kubectl get pods -n <namespace> --show-labels
+
+   # Ensure labels match
+   ```
+
+2. **Restart pods:**
+   ```bash
+   # Delete pods to recreate
+   kubectl delete pod -n <namespace> -l app=<app-name>
+
+   # Wait for recreation
+   kubectl wait --for=condition=ready pod -n <namespace> -l app=<app-name>
+   ```
+
+---
+
+### Issue: ImagePullBackOff errors
+
+**Symptoms:**
+- Pods fail to start
+- Status shows "ImagePullBackOff" or "ErrImagePull"
+- Image pull errors in events
+
+**Diagnosis:**
+```bash
+# Describe pod
+kubectl describe pod <pod-name> -n <namespace>
+
+# Check for image pull errors in events
+kubectl get events -n <namespace> | grep -i pull
+```
+
+**Solutions:**
+
+1. **Check image exists:**
+   ```bash
+   # Verify image in registry
+   docker pull <image>:<tag>
+
+   # Or use crictl on node
+   sudo crictl pull <image>:<tag>
+   ```
+
+2. **Fix image pull secrets:**
+   ```bash
+   # Create secret if needed
+   kubectl create secret docker-registry regcred \
+     --docker-server=<registry> \
+     --docker-username=<username> \
+     --docker-password=<password> \
+     -n <namespace>
+
+   # Patch deployment to use secret
+   kubectl patch deployment <name> \
+     -n <namespace> \
+     -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name":"regcred"}]}}}}'
+   ```
+
+---
+
+## Performance Issues
+
+### Issue: Build is very slow
+
+**Symptoms:**
+- Build takes over 30 minutes
+- Downloads are slow
+- CPU at 100%
+
+**Diagnosis:**
+```bash
+# Check network speed
+wget --output-document=/dev/null http://speedtest.wdc01.softlayer.com/downloads/test100.zip
+
+# Check CPU usage
+top
+
+# Check disk I/O
+iostat -x 1 10
+```
+
+**Solutions:**
+
+1. **Use local registry:**
+   ```bash
+   # Set up Zot locally (see README.md)
+
+   # Configure hhfab to use local registry
+   hhfab init --dev --registry-repo 127.0.0.1:30000
+
+   # Subsequent builds will be much faster
+   ```
+
+2. **Move cache to SSD:**
+   ```bash
+   # Move cache to faster disk
+   export HHFAB_CACHE_DIR=/mnt/ssd/hhfab-cache
+   hhfab build --mode iso
+   ```
+
+3. **Use build cache:**
+   ```bash
+   # Don't clear cache between builds
+   # Only rebuild when config changes
+
+   # Builds with cache: ~2-3 minutes
+   # Builds without: ~10-15 minutes
+   ```
+
+---
+
+### Issue: VLAB VMs are slow
+
+**Symptoms:**
+- VMs respond slowly
+- SSH sessions lag
+- Installation takes very long
+
+**Diagnosis:**
+```bash
+# Check host resources
+top
+free -h
+
+# Check VM CPU allocation
+virsh vcpuinfo control-1
+
+# Check VM memory
+virsh dominfo control-1 | grep memory
+```
+
+**Solutions:**
+
+1. **Increase VM resources:**
+   ```bash
+   # Edit VLAB config to increase CPU/RAM
+   # In vlab configuration, adjust:
+   # - CPU cores
+   # - Memory allocation
+   ```
+
+2. **Reduce concurrent VMs:**
+   ```bash
+   # Build only controls
+   hhfab build --controls --no-gateways
+
+   # Or run VLAB with fewer switches
+   hhfab vlab gen --fabric-mode minimal
+   ```
+
+---
+
+## Getting More Help
+
+If issues persist after trying these solutions:
+
+1. **Collect debug information:**
+   ```bash
+   ./hack/debug/collect-debug-info.sh > debug-info.txt
+   ```
+
+2. **Enable verbose logging:**
+   ```bash
+   hhfab --verbose <command> 2>&1 | tee verbose-output.log
+   ```
+
+3. **File a GitHub issue** with:
+   - Problem description
+   - Steps to reproduce
+   - Debug information from step 1
+   - Verbose output from step 2
+   - Environment details (OS, versions, etc.)
+
+---
+
+## Related Documentation
+
+- [Debug Guide](DEBUG_GUIDE.md) - Comprehensive debugging instructions
+- [Usage Guide](../usage/USAGE_GUIDE.md) - Common usage patterns
+- [README](../../README.md) - Project overview and setup
+
+---
+
+**Last Updated:** 2025-11-08
+**Maintained By:** Hedgehog Fabricator Team
+**Issue:** #8

--- a/docs/usage/USAGE_GUIDE.md
+++ b/docs/usage/USAGE_GUIDE.md
@@ -1,0 +1,686 @@
+# Fabricator Usage Guide
+
+**Version:** 1.0
+**Date:** 2025-11-08
+**Issue:** #8
+
+## Overview
+
+This guide provides comprehensive usage instructions for Hedgehog Fabricator, covering common workflows, examples, and best practices for developers and operators.
+
+## Table of Contents
+
+1. [Quick Start](#quick-start)
+2. [Project Initialization](#project-initialization)
+3. [Configuration](#configuration)
+4. [Building Images](#building-images)
+5. [VLAB Operations](#vlab-operations)
+6. [Testing](#testing)
+7. [Common Workflows](#common-workflows)
+8. [Best Practices](#best-practices)
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+Ensure you have all required tools installed:
+
+```bash
+# Verify Go version (v1.24.0+)
+go version
+
+# Verify Docker (v17.03+)
+docker --version
+
+# Verify Just (v1.36.0+)
+just --version
+
+# Verify Zot is running (optional for local registry)
+curl http://127.0.0.1:30000/v2/_catalog
+```
+
+### Clone and Build
+
+```bash
+# Clone the repository
+git clone https://github.com/githedgehog/fabricator.git
+cd fabricator
+
+# Set up local registry (one-time setup)
+# See README.md for Zot installation instructions
+
+# Build all artifacts
+just push
+
+# Verify binaries created
+ls -lh bin/
+```
+
+---
+
+## Project Initialization
+
+### Initialize New Fabric Configuration
+
+```bash
+# Initialize with defaults
+hhfab init --dev
+
+# Initialize with custom options
+hhfab init \
+  --dev \
+  --registry-repo 127.0.0.1:30000 \
+  --default-password-hash '$6$rounds=4096$...' \
+  --default-authorized-keys "$(cat ~/.ssh/id_rsa.pub)"
+
+# Initialize with TLS SANs
+hhfab init \
+  --dev \
+  --tls-san "fabric.example.com" \
+  --tls-san "10.10.10.10"
+```
+
+This creates:
+- `fab.yaml` - Main configuration file
+- `wiring/` - Directory for wiring diagrams
+
+### Import Existing Configuration
+
+```bash
+# Import from host
+hhfab import \
+  --import-host-upstream https://existing-fabric.example.com:6443 \
+  --config /path/to/config
+```
+
+---
+
+## Configuration
+
+### Edit Fabric Configuration
+
+Edit `fab.yaml`:
+
+```yaml
+apiVersion: fabricator.githedgehog.com/v1beta1
+kind: Fabricator
+metadata:
+  name: default
+spec:
+  config:
+    # Registry configuration
+    repo: ghcr.io
+    prefix: githedgehog
+    registryMode: proxy  # or airgap, upstream
+
+    # Default credentials
+    defaultUser: admin
+    defaultPasswordHash: $6$rounds=4096$...
+    defaultAuthorizedKeys:
+      - ssh-rsa AAAAB3NzaC1...
+
+    # Version overrides (optional)
+    versions:
+      platform:
+        k3s: v1.34.1-k3s1
+        zot: v2.1.9
+```
+
+### Create Wiring Diagrams
+
+Create files in `wiring/` directory:
+
+```bash
+# Example: wiring/fabric.yaml
+apiVersion: wiring.githedgehog.com/v1beta1
+kind: Fabric
+metadata:
+  name: my-fabric
+spec:
+  spines:
+    - name: spine-1
+      asn: 65100
+    - name: spine-2
+      asn: 65100
+  leaves:
+    - name: leaf-1
+      asn: 65101
+    - name: leaf-2
+      asn: 65102
+```
+
+### Validate Configuration
+
+```bash
+# Validate configuration files
+hhfab config validate
+
+# Show merged configuration
+hhfab config show
+```
+
+---
+
+## Building Images
+
+### Build Controller ISO
+
+Standard build for control nodes:
+
+```bash
+# Build ISO (default)
+hhfab build --mode iso
+
+# Build only controls (skip gateways)
+hhfab build --controls --no-gateways
+
+# Build with verbose output
+hhfab --verbose build --mode iso
+```
+
+Output location: `workdir/result/control--<name>--install-usb.iso`
+
+### Build USB Image
+
+For USB installation media:
+
+```bash
+# Build bootable USB image
+hhfab build --mode usb
+```
+
+Output: `workdir/result/control--<name>--install-usb.img`
+
+To write to USB drive:
+
+```bash
+sudo dd if=workdir/result/control--ctrl-1--install-usb.img \
+  of=/dev/sdX \
+  bs=4M \
+  status=progress \
+  conv=fsync
+```
+
+### Build Manual Installation
+
+Separate archive and ignition config:
+
+```bash
+# Build manual installation bundle
+hhfab build --mode manual
+```
+
+Outputs:
+- `control--<name>--install.tgz` - Installation archive
+- `control--<name>--install.ign` - Ignition configuration
+
+### Build with Custom Registry
+
+```bash
+# Use local registry
+hhfab build \
+  --mode iso \
+  --config fab.yaml
+
+# Specify registry in fab.yaml:
+# spec.config.repo: 127.0.0.1:30000
+# spec.config.prefix: githedgehog
+```
+
+### Build in Airgap Mode
+
+For offline installations:
+
+```yaml
+# In fab.yaml
+spec:
+  config:
+    registryMode: airgap
+```
+
+```bash
+# Build with all artifacts embedded
+hhfab build --mode iso
+```
+
+**Note:** Airgap builds are significantly larger (~12-15 GB vs ~9.5 GB)
+
+---
+
+## VLAB Operations
+
+### Generate VLAB Configuration
+
+```bash
+# Generate basic VLAB
+hhfab vlab gen
+
+# Generate with specific options
+hhfab vlab gen \
+  --fabric-mode spine-leaf \
+  --control-node-mgmt-link direct \
+  --gateway
+```
+
+### Start VLAB
+
+```bash
+# Start VLAB with ISO mode
+hhfab vlab up --mode iso
+
+# Start with specific options
+hhfab vlab up \
+  --mode iso \
+  --kill-stale \
+  --recreate
+
+# Wait for ready state
+hhfab vlab up --mode iso --ready
+```
+
+### Monitor VLAB
+
+```bash
+# Check VLAB status
+hhfab vlab status
+
+# Check specific components
+kubectl get nodes
+kubectl get pods -A
+
+# Access control node
+ssh core@<control-ip>
+```
+
+### Stop VLAB
+
+```bash
+# Stop VLAB
+hhfab vlab down
+
+# Force cleanup
+hhfab vlab down --force
+```
+
+### VLAB Console Access
+
+```bash
+# Connect to control node console
+virsh console control-1
+
+# Disconnect: Ctrl+] then Ctrl+5
+```
+
+---
+
+## Testing
+
+### Run Unit Tests
+
+```bash
+# Run all tests
+just test
+
+# Run specific package tests
+go test ./pkg/hhfab/...
+
+# Run with verbose output
+go test -v ./pkg/...
+```
+
+### Run Integration Tests
+
+```bash
+# Run VLAB tests
+hhfab vlab test
+
+# Run with specific test filter
+hhfab vlab test --regex "TestNetworking"
+
+# Run extended tests
+hhfab vlab test --extended
+```
+
+### Run Security Scans
+
+```bash
+# Run Trivy security scan
+just security-scan
+
+# Run control-only scan
+just security-scan --control-only
+
+# Run with strict mode
+just security-scan --strict
+```
+
+---
+
+## Common Workflows
+
+### Workflow 1: Local Development Build
+
+```bash
+# 1. Make code changes
+vim pkg/hhfab/cmdbuild.go
+
+# 2. Build and push to local registry
+just oci=http push
+
+# 3. Verify binaries
+ls -lh bin/hhfab
+
+# 4. Test locally
+bin/hhfab build --mode iso --registry-repo 127.0.0.1:30000
+```
+
+### Workflow 2: Test Configuration Changes
+
+```bash
+# 1. Update configuration
+vim fab.yaml
+
+# 2. Validate
+hhfab config validate
+
+# 3. Rebuild
+hhfab build --mode iso
+
+# 4. Test in VLAB
+hhfab vlab up --mode iso --recreate
+```
+
+### Workflow 3: Upgrade Testing
+
+```bash
+# 1. Build new version
+just push
+
+# 2. Start VLAB with old version
+hhfab vlab up --mode iso
+
+# 3. Upgrade to new version
+hhfab upgrade --version <new-version>
+
+# 4. Verify upgrade
+kubectl get nodes
+kubectl get pods -A
+```
+
+### Workflow 4: Multi-Platform Build
+
+```bash
+# Build for all supported platforms
+just build-multi
+
+# Outputs in bin/:
+# - hhfab-linux-amd64.tar.gz
+# - hhfab-linux-arm64.tar.gz
+# - hhfab-darwin-amd64.tar.gz
+# - hhfab-darwin-arm64.tar.gz
+```
+
+### Workflow 5: Airgap Deployment
+
+```bash
+# 1. Configure airgap mode
+cat > fab.yaml <<EOF
+spec:
+  config:
+    registryMode: airgap
+EOF
+
+# 2. Build airgap ISO
+hhfab build --mode iso
+
+# 3. Transfer ISO to offline system
+scp workdir/result/control--*.iso offline-system:/tmp/
+
+# 4. Install on offline system
+# Boot from ISO, installation proceeds without internet
+```
+
+---
+
+## Best Practices
+
+### 1. Use Version Control for Configuration
+
+```bash
+# Initialize git repository for config
+git init
+git add fab.yaml wiring/
+git commit -m "Initial fabric configuration"
+```
+
+### 2. Use Local Registry for Development
+
+```bash
+# Always specify local registry
+hhfab build --mode iso --registry-repo 127.0.0.1:30000
+
+# Or set in fab.yaml
+spec:
+  config:
+    repo: 127.0.0.1:30000
+```
+
+### 3. Enable Verbose Logging for Debugging
+
+```bash
+# Set environment variable
+export HHFAB_VERBOSE=true
+
+# Or use flag
+hhfab --verbose <command>
+```
+
+### 4. Clean Cache Regularly
+
+```bash
+# Check cache size
+du -sh ~/.hhfab-cache/
+
+# Clear old artifacts
+find ~/.hhfab-cache/v1/ -mtime +30 -delete
+
+# Full cache clear
+rm -rf ~/.hhfab-cache/v1/*
+```
+
+### 5. Use Build Cache for Speed
+
+```bash
+# First build (downloads all artifacts)
+hhfab build --mode iso  # Takes ~10-15 minutes
+
+# Subsequent builds (uses cache)
+hhfab build --mode iso  # Takes ~2-3 minutes if no config changes
+```
+
+### 6. Test Before Deployment
+
+```bash
+# Always test in VLAB first
+hhfab vlab gen
+hhfab vlab up --mode iso
+hhfab vlab test
+
+# Verify before deploying to production
+hhfab vlab status
+kubectl get nodes
+kubectl get pods -A
+```
+
+### 7. Document Custom Configurations
+
+```bash
+# Add comments to fab.yaml
+apiVersion: fabricator.githedgehog.com/v1beta1
+kind: Fabricator
+metadata:
+  name: default
+spec:
+  config:
+    # Using airgap mode for datacenter deployment
+    registryMode: airgap
+
+    # Custom K3s version for stability
+    versions:
+      platform:
+        k3s: v1.34.1-k3s1  # Tested and verified
+```
+
+### 8. Backup Configurations
+
+```bash
+# Backup before major changes
+tar -czf fabric-config-$(date +%Y%m%d).tar.gz \
+  fab.yaml wiring/ workdir/
+
+# Restore if needed
+tar -xzf fabric-config-20251108.tar.gz
+```
+
+### 9. Monitor Build Sizes
+
+```bash
+# Check ISO size before deployment
+ls -lh workdir/result/*.iso
+
+# Expected sizes:
+# - Standard: ~9.5 GB
+# - Airgap: ~12-15 GB
+
+# If size is unexpected, check verbose build output
+```
+
+### 10. Use Just for Common Tasks
+
+```bash
+# List available commands
+just
+
+# Common tasks
+just push          # Build and push all artifacts
+just build         # Build only
+just test          # Run tests
+just lint          # Run linters
+just all           # Generate, lint, test, build everything
+```
+
+---
+
+## Environment Variables
+
+Supported environment variables:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HHFAB_VERBOSE` | Enable verbose logging | `false` |
+| `HHFAB_CACHE_DIR` | Cache directory location | `~/.hhfab-cache` |
+| `HHFAB_PREVIEW` | Enable preview features | `false` |
+
+Example usage:
+
+```bash
+# Set for current session
+export HHFAB_VERBOSE=true
+export HHFAB_CACHE_DIR=/mnt/large-disk/cache
+
+# Run command with variables
+HHFAB_VERBOSE=true hhfab build --mode iso
+```
+
+---
+
+## Tips and Tricks
+
+### Tip 1: Speed Up Builds
+
+```bash
+# Use local registry for faster artifact access
+hhfab init --dev --registry-repo 127.0.0.1:30000
+
+# Keep cache directory on fast SSD
+export HHFAB_CACHE_DIR=/mnt/ssd/hhfab-cache
+```
+
+### Tip 2: Quick VLAB Iteration
+
+```bash
+# Generate once, reuse config
+hhfab vlab gen
+# ... make changes ...
+hhfab vlab up --mode iso --recreate --kill-stale
+```
+
+### Tip 3: Parallel Development
+
+```bash
+# Use separate work directories for different configs
+hhfab build --mode iso --config /path/to/config1
+hhfab build --mode iso --config /path/to/config2
+```
+
+### Tip 4: Extract ISO Contents
+
+```bash
+# Mount ISO to inspect contents
+sudo mount -o loop control--ctrl-1--install-usb.iso /mnt
+ls -la /mnt
+sudo umount /mnt
+```
+
+### Tip 5: Quick Config Validation
+
+```bash
+# Validate without building
+hhfab config validate
+
+# Show effective configuration
+hhfab config show | less
+```
+
+---
+
+## Troubleshooting Quick Reference
+
+Common issues and quick fixes:
+
+| Issue | Quick Fix |
+|-------|-----------|
+| Build cache errors | `rm -rf ~/.hhfab-cache/v1/*` |
+| Registry auth fails | `docker login ghcr.io` |
+| Build hangs | Check network, firewall, disk space |
+| VLAB won't start | `hhfab vlab down --force && hhfab vlab up --mode iso --recreate` |
+| K3s fails | `journalctl -u k3s \| tail -50` |
+
+For detailed troubleshooting, see [Debug Guide](../debug/DEBUG_GUIDE.md) and [Troubleshooting Guide](../debug/TROUBLESHOOTING.md).
+
+---
+
+## Getting Help
+
+- **Debug Guide:** [docs/debug/DEBUG_GUIDE.md](../debug/DEBUG_GUIDE.md)
+- **Troubleshooting:** [docs/debug/TROUBLESHOOTING.md](../debug/TROUBLESHOOTING.md)
+- **API Docs:** [docs/api.md](../api.md)
+- **GitHub Issues:** [github.com/githedgehog/fabricator/issues](https://github.com/githedgehog/fabricator/issues)
+
+---
+
+## Related Documentation
+
+- [README](../../README.md) - Project overview and setup
+- [Debug Guide](../debug/DEBUG_GUIDE.md) - Comprehensive debugging instructions
+- [Troubleshooting Guide](../debug/TROUBLESHOOTING.md) - Specific problem solutions
+- [Trivy Scans](../../hack/README_Trivy_Scans.md) - Security scanning guide
+- [Test Diagrams](../../hack/README_Test_Diagrams.md) - Testing documentation
+
+---
+
+**Last Updated:** 2025-11-08
+**Maintained By:** Hedgehog Fabricator Team
+**Issue:** #8

--- a/hack/debug/check-vlab-health.sh
+++ b/hack/debug/check-vlab-health.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Copyright 2024 Hedgehog
+# SPDX-License-Identifier: Apache-2.0
+
+# VLAB Health Check Script
+# Checks health of running VLAB environment
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "=== VLAB Health Check ==="
+echo "Timestamp: $(date)"
+echo ""
+
+echo "=== Libvirt Status ==="
+if ! systemctl is-active --quiet libvirtd; then
+    echo -e "${RED}✗${NC} libvirtd is not running"
+    exit 1
+else
+    echo -e "${GREEN}✓${NC} libvirtd is running"
+fi
+echo ""
+
+echo "=== Virtual Machines ==="
+vms=$(virsh list --all --name 2>/dev/null || echo "")
+if [ -z "$vms" ]; then
+    echo -e "${YELLOW}!${NC} No VMs found"
+else
+    echo "Found VMs:"
+    virsh list --all
+fi
+echo ""
+
+echo "=== VM Connectivity ==="
+running_vms=$(virsh list --name 2>/dev/null || echo "")
+if [ -z "$running_vms" ]; then
+    echo -e "${YELLOW}!${NC} No running VMs"
+else
+    for vm in $running_vms; do
+        # Try to get IP
+        ip=$(virsh domifaddr "$vm" 2>/dev/null | awk 'NR>2 {print $4}' | cut -d/ -f1 | head -1)
+        if [ -n "$ip" ]; then
+            # Try to ping
+            if ping -c 1 -W 2 "$ip" > /dev/null 2>&1; then
+                echo -e "${GREEN}✓${NC} $vm ($ip): reachable"
+            else
+                echo -e "${YELLOW}!${NC} $vm ($ip): not responding to ping"
+            fi
+        else
+            echo -e "${YELLOW}!${NC} $vm: no IP address assigned"
+        fi
+    done
+fi
+echo ""
+
+echo "=== Network Bridges ==="
+if command -v brctl &> /dev/null; then
+    brctl show
+else
+    echo -e "${YELLOW}!${NC} brctl not available"
+fi
+echo ""
+
+echo "=== Kubernetes Cluster ==="
+if command -v kubectl &> /dev/null; then
+    if kubectl cluster-info &> /dev/null; then
+        echo -e "${GREEN}✓${NC} Kubernetes cluster is accessible"
+        echo ""
+        echo "Nodes:"
+        kubectl get nodes
+        echo ""
+        echo "Pods (fabricator-system):"
+        kubectl get pods -n fabricator-system 2>/dev/null || echo "fabricator-system namespace not found"
+        echo ""
+        echo "Pods (kube-system):"
+        kubectl get pods -n kube-system | head -10
+    else
+        echo -e "${YELLOW}!${NC} Cannot connect to Kubernetes cluster"
+    fi
+else
+    echo -e "${YELLOW}!${NC} kubectl not available"
+fi
+echo ""
+
+echo "=== Control Node Services ==="
+control_vms=$(virsh list --name 2>/dev/null | grep -E 'control|ctrl' || echo "")
+if [ -n "$control_vms" ]; then
+    for vm in $control_vms; do
+        echo "Checking $vm..."
+        ip=$(virsh domifaddr "$vm" 2>/dev/null | awk 'NR>2 {print $4}' | cut -d/ -f1 | head -1)
+        if [ -n "$ip" ]; then
+            # Try SSH
+            if ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no core@"$ip" "systemctl is-active k3s" &> /dev/null; then
+                echo -e "  ${GREEN}✓${NC} K3s is running"
+            else
+                echo -e "  ${YELLOW}!${NC} K3s status unknown (SSH failed)"
+            fi
+        else
+            echo -e "  ${YELLOW}!${NC} No IP address"
+        fi
+    done
+else
+    echo -e "${YELLOW}!${NC} No control VMs found"
+fi
+echo ""
+
+echo "=== Resource Usage ==="
+echo "Host CPU:"
+top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}'
+echo ""
+echo "Host Memory:"
+free -h | grep Mem
+echo ""
+echo "Host Disk:"
+df -h / | awk 'NR==2 {print "Used: " $3 " / " $2 " (" $5 ")"}'
+echo ""
+
+echo "=== VM Resource Allocation ==="
+for vm in $running_vms; do
+    echo "$vm:"
+    virsh dominfo "$vm" | grep -E "(CPU|memory|Max memory)"
+    echo ""
+done
+
+echo "=== Health Check Complete ==="

--- a/hack/debug/collect-debug-info.sh
+++ b/hack/debug/collect-debug-info.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Copyright 2024 Hedgehog
+# SPDX-License-Identifier: Apache-2.0
+
+# Collect Debug Information Script
+# Collects system and environment information for debugging fabricator issues
+
+set -euo pipefail
+
+echo "=== Fabricator Debug Information Collection ==="
+echo "Generated: $(date)"
+echo ""
+
+echo "=== System Information ==="
+echo "Hostname: $(hostname)"
+echo "OS: $(cat /etc/os-release | grep PRETTY_NAME | cut -d= -f2)"
+echo "Kernel: $(uname -r)"
+echo "Architecture: $(uname -m)"
+echo ""
+
+echo "=== Hardware Resources ==="
+echo "CPU Cores: $(nproc)"
+echo "Memory:"
+free -h
+echo ""
+echo "Disk Space:"
+df -h | grep -E '(Filesystem|/dev/|/mnt)'
+echo ""
+
+echo "=== Software Versions ==="
+echo "Go: $(go version 2>/dev/null || echo 'not installed')"
+echo "Docker: $(docker --version 2>/dev/null || echo 'not installed')"
+echo "Just: $(just --version 2>/dev/null || echo 'not installed')"
+echo "Kubectl: $(kubectl version --client --short 2>/dev/null || echo 'not installed')"
+echo "Virsh: $(virsh --version 2>/dev/null || echo 'not installed')"
+echo ""
+
+echo "=== Docker Status ==="
+if command -v docker &> /dev/null; then
+    docker info 2>&1 | head -20 || echo "Docker not running"
+else
+    echo "Docker not installed"
+fi
+echo ""
+
+echo "=== Fabricator Cache ==="
+if [ -d "$HOME/.hhfab-cache" ]; then
+    echo "Cache location: $HOME/.hhfab-cache"
+    echo "Cache size: $(du -sh $HOME/.hhfab-cache 2>/dev/null | cut -f1)"
+    echo "Cached artifacts:"
+    ls -1 "$HOME/.hhfab-cache/v1/" 2>/dev/null | head -10 || echo "No artifacts cached"
+else
+    echo "No cache directory found"
+fi
+echo ""
+
+echo "=== Network Configuration ==="
+echo "Interfaces:"
+ip -br addr show
+echo ""
+echo "Default route:"
+ip route show default
+echo ""
+echo "DNS:"
+cat /etc/resolv.conf | grep -v "^#"
+echo ""
+
+echo "=== Environment Variables ==="
+echo "HHFAB_VERBOSE: ${HHFAB_VERBOSE:-not set}"
+echo "HHFAB_CACHE_DIR: ${HHFAB_CACHE_DIR:-not set}"
+echo "HHFAB_PREVIEW: ${HHFAB_PREVIEW:-not set}"
+echo "HTTP_PROXY: ${HTTP_PROXY:-not set}"
+echo "HTTPS_PROXY: ${HTTPS_PROXY:-not set}"
+echo ""
+
+echo "=== Registry Connectivity ==="
+echo "Testing ghcr.io..."
+if curl -s -I https://ghcr.io/v2/ > /dev/null 2>&1; then
+    echo "  ✓ ghcr.io is reachable"
+else
+    echo "  ✗ ghcr.io is NOT reachable"
+fi
+
+echo "Testing local registry (127.0.0.1:30000)..."
+if curl -s http://127.0.0.1:30000/v2/_catalog > /dev/null 2>&1; then
+    echo "  ✓ Local registry is running"
+else
+    echo "  ✗ Local registry is NOT running"
+fi
+echo ""
+
+if [ -d "workdir" ]; then
+    echo "=== Build Artifacts ==="
+    echo "Workdir exists: yes"
+    if [ -d "workdir/result" ]; then
+        echo "Result directory size: $(du -sh workdir/result 2>/dev/null | cut -f1)"
+        echo "Artifacts:"
+        ls -lh workdir/result/ 2>/dev/null | grep -E '\.(iso|img|tgz|ign)$' || echo "No artifacts found"
+    else
+        echo "No result directory"
+    fi
+    echo ""
+fi
+
+if command -v kubectl &> /dev/null && kubectl cluster-info &> /dev/null; then
+    echo "=== Kubernetes Cluster Info ==="
+    echo "Cluster:"
+    kubectl cluster-info 2>/dev/null || echo "No cluster connection"
+    echo ""
+    echo "Nodes:"
+    kubectl get nodes 2>/dev/null || echo "Cannot get nodes"
+    echo ""
+    echo "Pods (all namespaces):"
+    kubectl get pods -A 2>/dev/null | head -20 || echo "Cannot get pods"
+    echo ""
+fi
+
+if command -v virsh &> /dev/null; then
+    echo "=== VLAB Status ==="
+    echo "Libvirt VMs:"
+    virsh list --all 2>/dev/null || echo "Cannot query libvirt"
+    echo ""
+    echo "Network bridges:"
+    brctl show 2>/dev/null || echo "brctl not available"
+    echo ""
+fi
+
+echo "=== Recent System Logs ==="
+echo "Checking for hhfab-install service..."
+if systemctl list-units --type=service | grep -q hhfab-install; then
+    echo "Last 20 lines of hhfab-install.service:"
+    journalctl -u hhfab-install.service -n 20 --no-pager 2>/dev/null || echo "Cannot read service logs"
+else
+    echo "hhfab-install.service not found (normal if not on installed node)"
+fi
+echo ""
+
+echo "=== Debug Information Collection Complete ==="
+echo ""
+echo "To save this output to a file:"
+echo "  $0 > debug-info.txt"
+echo ""
+echo "To share this information, review and redact any sensitive data,"
+echo "then attach debug-info.txt to your GitHub issue."

--- a/hack/debug/verify-system.sh
+++ b/hack/debug/verify-system.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Copyright 2024 Hedgehog
+# SPDX-License-Identifier: Apache-2.0
+
+# System Requirements Verification Script
+# Verifies that system meets requirements for fabricator development
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+errors=0
+warnings=0
+
+check_command() {
+    local cmd=$1
+    local required=$2
+    local min_version=${3:-}
+
+    if command -v "$cmd" &> /dev/null; then
+        local version=$($cmd --version 2>&1 | head -1 || echo "unknown")
+        echo -e "${GREEN}✓${NC} $cmd: $version"
+
+        if [ -n "$min_version" ]; then
+            # Version checking would go here
+            :
+        fi
+    else
+        if [ "$required" = "yes" ]; then
+            echo -e "${RED}✗${NC} $cmd: NOT FOUND (required)"
+            ((errors++))
+        else
+            echo -e "${YELLOW}!${NC} $cmd: NOT FOUND (optional)"
+            ((warnings++))
+        fi
+    fi
+}
+
+check_service() {
+    local service=$1
+    local required=$2
+
+    if systemctl is-active --quiet "$service" 2>/dev/null; then
+        echo -e "${GREEN}✓${NC} $service: running"
+    elif systemctl list-unit-files | grep -q "^$service"; then
+        echo -e "${YELLOW}!${NC} $service: not running"
+        if [ "$required" = "yes" ]; then
+            ((errors++))
+        else
+            ((warnings++))
+        fi
+    else
+        if [ "$required" = "yes" ]; then
+            echo -e "${RED}✗${NC} $service: NOT INSTALLED (required)"
+            ((errors++))
+        else
+            echo -e "${YELLOW}!${NC} $service: not installed (optional)"
+            ((warnings++))
+        fi
+    fi
+}
+
+check_port() {
+    local port=$1
+    local name=$2
+
+    if nc -z localhost "$port" 2>/dev/null || curl -s "http://localhost:$port" > /dev/null 2>&1; then
+        echo -e "${GREEN}✓${NC} $name (port $port): accessible"
+    else
+        echo -e "${YELLOW}!${NC} $name (port $port): not accessible"
+        ((warnings++))
+    fi
+}
+
+echo "=== Fabricator System Requirements Verification ==="
+echo ""
+
+echo "=== Required Commands ==="
+check_command "go" "yes"
+check_command "docker" "yes"
+check_command "just" "yes"
+check_command "git" "yes"
+echo ""
+
+echo "=== Optional Commands ==="
+check_command "kubectl" "no"
+check_command "virsh" "no"
+check_command "k9s" "no"
+check_command "oras" "no"
+echo ""
+
+echo "=== System Services ==="
+check_service "docker" "yes"
+check_service "libvirtd" "no"
+echo ""
+
+echo "=== Local Registry ==="
+check_port "30000" "Zot registry"
+echo ""
+
+echo "=== Resource Requirements ==="
+
+# Check CPU cores
+cpu_cores=$(nproc)
+if [ "$cpu_cores" -ge 4 ]; then
+    echo -e "${GREEN}✓${NC} CPU cores: $cpu_cores (minimum 4)"
+else
+    echo -e "${RED}✗${NC} CPU cores: $cpu_cores (minimum 4 required)"
+    ((errors++))
+fi
+
+# Check memory
+mem_gb=$(free -g | awk '/^Mem:/{print $2}')
+if [ "$mem_gb" -ge 8 ]; then
+    echo -e "${GREEN}✓${NC} Memory: ${mem_gb}GB (minimum 8GB)"
+else
+    echo -e "${YELLOW}!${NC} Memory: ${mem_gb}GB (8GB recommended)"
+    ((warnings++))
+fi
+
+# Check disk space
+root_free=$(df -BG / | awk 'NR==2 {print $4}' | tr -d 'G')
+if [ "$root_free" -ge 50 ]; then
+    echo -e "${GREEN}✓${NC} Disk space (/): ${root_free}GB free (minimum 50GB)"
+else
+    echo -e "${RED}✗${NC} Disk space (/): ${root_free}GB free (minimum 50GB required)"
+    ((errors++))
+fi
+
+echo ""
+
+echo "=== Network Connectivity ==="
+
+# Test ghcr.io
+if curl -s -I --max-time 5 https://ghcr.io/v2/ > /dev/null 2>&1; then
+    echo -e "${GREEN}✓${NC} ghcr.io: reachable"
+else
+    echo -e "${RED}✗${NC} ghcr.io: NOT reachable"
+    ((errors++))
+fi
+
+# Test DNS
+if nslookup google.com > /dev/null 2>&1; then
+    echo -e "${GREEN}✓${NC} DNS resolution: working"
+else
+    echo -e "${RED}✗${NC} DNS resolution: failing"
+    ((errors++))
+fi
+
+echo ""
+
+echo "=== Go Environment ==="
+if command -v go &> /dev/null; then
+    echo "GOROOT: ${GOROOT:-not set}"
+    echo "GOPATH: ${GOPATH:-not set}"
+    echo "Go modules: $(go env GOMOD 2>/dev/null || echo 'N/A')"
+fi
+echo ""
+
+echo "=== Docker Configuration ==="
+if command -v docker &> /dev/null && docker info &> /dev/null; then
+    echo "Docker root: $(docker info 2>/dev/null | grep 'Docker Root Dir' | cut -d: -f2 | xargs)"
+    echo "Storage driver: $(docker info 2>/dev/null | grep 'Storage Driver' | cut -d: -f2 | xargs)"
+    echo "Logged in registries:"
+    if [ -f "$HOME/.docker/config.json" ]; then
+        cat "$HOME/.docker/config.json" | jq -r '.auths | keys[]' 2>/dev/null || echo "  Unable to parse config"
+    else
+        echo "  No credentials configured"
+    fi
+fi
+echo ""
+
+echo "=== Summary ==="
+echo -e "Errors: ${RED}$errors${NC}"
+echo -e "Warnings: ${YELLOW}$warnings${NC}"
+echo ""
+
+if [ $errors -eq 0 ]; then
+    echo -e "${GREEN}✓ System meets minimum requirements for fabricator development${NC}"
+    exit 0
+else
+    echo -e "${RED}✗ System does NOT meet minimum requirements${NC}"
+    echo ""
+    echo "Please address the errors above before proceeding."
+    echo "See README.md for installation instructions."
+    exit 1
+fi


### PR DESCRIPTION
Closes #14

## Summary
Removes the `ubuntu-24.04-arm64-4-core` runner from the bundle job matrix to speed up CI execution.

## Changes
- Updated `.github/workflows/ci.yaml` to remove arm64 from the matrix
- Bundle job now only runs on `ubuntu-latest-x86-4-cores` and `macos-latest`

## Rationale
The fork won't ship arm artifacts in the foreseeable future. Removing this runner avoids multi-hour waits on arm queue delays.

## Testing
CI will validate the change on this PR.